### PR TITLE
fix: make resolution optional in list_futures_aggregates to include in query params

### DIFF
--- a/polygon/rest/futures.py
+++ b/polygon/rest/futures.py
@@ -26,7 +26,7 @@ class FuturesClient(BaseClient):
     def list_futures_aggregates(
         self,
         ticker: str,
-        resolution: str,
+        resolution: Optional[str] = None,
         window_start: Optional[str] = None,
         window_start_lt: Optional[str] = None,
         window_start_lte: Optional[str] = None,


### PR DESCRIPTION
This PR fixes an issue where the resolution parameter in list_futures_aggregates was not included in the API query parameters because it lacked a default value and was skipped by the _get_params method.