### PR TITLE
Remove unnecessary sqlite3 Timestamp import from summaries.py and indicators.py to fix mypy errors

### DIFF
--- a/polygon/rest/models/indicators.py
+++ b/polygon/rest/models/indicators.py
@@ -1,4 +1,3 @@
-from sqlite3 import Timestamp
 from typing import Optional, Any, Dict, List, Union
 from ...modelclass import modelclass
 from .aggs import Agg

--- a/polygon/rest/models/summaries.py
+++ b/polygon/rest/models/summaries.py
@@ -1,4 +1,3 @@
-from sqlite3 import Timestamp
 from typing import Optional
 from ...modelclass import modelclass
 from .tickers import Branding


### PR DESCRIPTION
This PR resolves mypy type-checking errors by removing the unused and invalid from sqlite3 import Timestamp line from polygon/rest/models/summaries.py and polygon/rest/models/indicators.py. The import was not referenced in the code and caused attribute-defined errors, as sqlite3 lacks a Timestamp attribute. No functional changes; tests should pass unchanged.