### PR TITLE
Log request URL with the Response headers

### DIFF
--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -113,7 +113,8 @@ class BaseClient:
                 print_headers["Authorization"] = print_headers["Authorization"].replace(
                     self.API_KEY, "REDACTED"
                 )
-            logger.info("Request URL: %s, Request Headers: %s", full_url, print_headers)
+            logger.info("Request URL: %s", full_url)
+            logger.info("Request Headers: %s", print_headers)
 
         resp = self.client.request(
             "GET",
@@ -124,7 +125,9 @@ class BaseClient:
 
         if self.trace:
             resp_headers_dict = dict(resp.headers.items())
-            logger.info("Response Headers: %s", resp_headers_dict)
+            logger.info(
+                "Request URL: %s, Response Headers: %s", full_url, resp_headers_dict
+            )
 
         if resp.status != 200:
             raise BadResponse(resp.data.decode("utf-8"))


### PR DESCRIPTION
It is difficult to match response headers to the request without corresponding request URL. This enables easier debugging.