### PR TITLE
[DVX-1136] Adds support for inflation expectations and futures exchanges endpoints

### DIFF
--- a/massive/rest/economy.py
+++ b/massive/rest/economy.py
@@ -6,6 +6,7 @@ from .base import BaseClient
 from .models.economy import (
     FedInflation,
     TreasuryYield,
+    FedInflationExpectations,
 )
 from .models.common import Sort, Order
 from .models.request import RequestOptionBuilder
@@ -83,5 +84,46 @@ class EconomyClient(BaseClient):
             params=self._get_params(self.list_inflation, locals()),
             raw=raw,
             deserializer=FedInflation.from_dict,
+            options=options,
+        )
+
+    def list_inflation_expectations(
+        self,
+        date: Optional[Union[str, date]] = None,
+        date_any_of: Optional[str] = None,
+        date_gt: Optional[Union[str, date]] = None,
+        date_gte: Optional[Union[str, date]] = None,
+        date_lt: Optional[Union[str, date]] = None,
+        date_lte: Optional[Union[str, date]] = None,
+        limit: Optional[int] = None,
+        sort: Optional[Union[str, Sort]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        raw: bool = False,
+        options: Optional[RequestOptionBuilder] = None,
+    ) -> Union[Iterator[FedInflationExpectations], HTTPResponse]:
+        """
+        A table tracking inflation expectations from both market-based and economic model perspectives across different time horizons.
+
+        :param date: Calendar date of the observation (YYYY-MM-DD).
+        :param date_any_of: Filter equal to any of the values. Multiple values can be specified by using a comma separated list.
+        :param date_gt: Filter greater than the value.
+        :param date_gte: Filter greater than or equal to the value.
+        :param date_lt: Filter less than the value.
+        :param date_lte: Filter less than or equal to the value.
+        :param limit: Limit the maximum number of results returned. Defaults to '100' if not specified. The maximum allowed limit is '50000'.
+        :param sort: A comma separated list of sort columns. For each column, append '.asc' or '.desc' to specify the sort direction. The sort column defaults to 'date' if not specified. The sort order defaults to 'asc' if not specified.
+        :param params: Additional query parameters.
+        :param raw: Return raw HTTPResponse object if True, else return Iterator[FedInflationExpectations].
+        :param options: RequestOptionBuilder for additional headers or params.
+        :return: An iterator of FedInflationExpectations objects or HTTPResponse if raw=True.
+        """
+        url = "/fed/v1/inflation-expectations"
+
+        return self._paginate(
+            path=url,
+            params=self._get_params(self.list_inflation_expectations, locals()),
+            deserializer=FedInflationExpectations.from_dict,
+            raw=raw,
+            result_key="results",
             options=options,
         )

--- a/massive/rest/futures.py
+++ b/massive/rest/futures.py
@@ -12,6 +12,7 @@ from .models.futures import (
     FuturesSchedule,
     FuturesMarketStatus,
     FuturesSnapshot,
+    FuturesExchange,
 )
 from .models.common import Sort
 from .models.request import RequestOptionBuilder
@@ -330,5 +331,26 @@ class FuturesClient(BaseClient):
             params=self._get_params(self.get_futures_snapshot, locals()),
             raw=raw,
             deserializer=FuturesSnapshot.from_dict,
+            options=options,
+        )
+
+    def list_futures_exchanges(
+        self,
+        limit: Optional[int] = None,
+        params: Optional[Dict[str, Any]] = None,
+        raw: bool = False,
+        options: Optional[RequestOptionBuilder] = None,
+    ) -> Union[Iterator[FuturesExchange], HTTPResponse]:
+        """
+        Endpoint: GET /futures/vX/exchanges
+
+        US futures exchanges and trading venues including major derivatives exchanges (CME, CBOT, NYMEX, COMEX) and other futures market infrastructure for commodity, financial, and other derivative contract trading.
+        """
+        url = "/futures/vX/exchanges"
+        return self._paginate(
+            path=url,
+            params=self._get_params(self.list_futures_exchanges, locals()),
+            raw=raw,
+            deserializer=FuturesExchange.from_dict,
             options=options,
         )

--- a/massive/rest/models/economy.py
+++ b/massive/rest/models/economy.py
@@ -60,3 +60,28 @@ class FedInflation:
             pce_core=d.get("pce_core"),
             pce_spending=d.get("pce_spending"),
         )
+
+
+@modelclass
+class FedInflationExpectations:
+    date: Optional[str] = None
+    forward_years_5_to_10: Optional[float] = None
+    market_10_year: Optional[float] = None
+    market_5_year: Optional[float] = None
+    model_10_year: Optional[float] = None
+    model_1_year: Optional[float] = None
+    model_30_year: Optional[float] = None
+    model_5_year: Optional[float] = None
+
+    @staticmethod
+    def from_dict(d):
+        return FedInflationExpectations(
+            date=d.get("date"),
+            forward_years_5_to_10=d.get("forward_years_5_to_10"),
+            market_10_year=d.get("market_10_year"),
+            market_5_year=d.get("market_5_year"),
+            model_10_year=d.get("model_10_year"),
+            model_1_year=d.get("model_1_year"),
+            model_30_year=d.get("model_30_year"),
+            model_5_year=d.get("model_5_year"),
+        )

--- a/massive/rest/models/futures.py
+++ b/massive/rest/models/futures.py
@@ -391,3 +391,33 @@ class FuturesSnapshot:
                 else None
             ),
         )
+
+
+@modelclass
+class FuturesExchange:
+    """
+    Represents a futures exchange or trading venue.
+    Corresponds to /futures/vX/exchanges endpoint.
+    """
+
+    acronym: Optional[str] = None
+    id: Optional[str] = None
+    locale: Optional[str] = None
+    mic: Optional[str] = None
+    name: Optional[str] = None
+    operating_mic: Optional[str] = None
+    type: Optional[str] = None
+    url: Optional[str] = None
+
+    @staticmethod
+    def from_dict(d):
+        return FuturesExchange(
+            acronym=d.get("acronym"),
+            id=d.get("id"),
+            locale=d.get("locale"),
+            mic=d.get("mic"),
+            name=d.get("name"),
+            operating_mic=d.get("operating_mic"),
+            type=d.get("type"),
+            url=d.get("url"),
+        )


### PR DESCRIPTION
This PR extends the client-python library by adding support for two new endpoints: /fed/v1/inflation-expectations (inflation expectations data) and /futures/vX/exchanges. Includes corresponding methods and models based on the OpenAPI specs.