### PR TITLE
Add report_sequence and sequence_number to FuturesQuote and FuturesTrade

### DIFF
--- a/massive/rest/models/futures.py
+++ b/massive/rest/models/futures.py
@@ -150,6 +150,8 @@ class FuturesQuote:
     bid_price: Optional[float] = None
     bid_size: Optional[float] = None
     bid_timestamp: Optional[int] = None
+    report_sequence: Optional[int] = None
+    sequence_number: Optional[int] = None
 
     @staticmethod
     def from_dict(d):
@@ -163,6 +165,8 @@ class FuturesQuote:
             bid_price=d.get("bid_price"),
             bid_size=d.get("bid_size"),
             bid_timestamp=d.get("bid_timestamp"),
+            report_sequence=d.get("report_sequence"),
+            sequence_number=d.get("sequence_number"),
         )
 
 
@@ -178,6 +182,8 @@ class FuturesTrade:
     session_end_date: Optional[str] = None
     price: Optional[float] = None
     size: Optional[float] = None
+    report_sequence: Optional[int] = None
+    sequence_number: Optional[int] = None
 
     @staticmethod
     def from_dict(d):
@@ -187,6 +193,8 @@ class FuturesTrade:
             session_end_date=d.get("session_end_date"),
             price=d.get("price"),
             size=d.get("size"),
+            report_sequence=d.get("report_sequence"),
+            sequence_number=d.get("sequence_number"),
         )
 
 


### PR DESCRIPTION
Added report_sequence and sequence_number to FuturesQuote and FuturesTrade

- Add missing required fields `report_sequence` and `sequence_number` (both int)
- Update both model classes and their `from_dict()` methods
- Sync with latest OpenAPI spec for /futures/vX/quotes/{ticker} and /futures/vX/trades/{ticker}