### PR TITLE
[bot] Add 8-K disclosures and disclosure categories endpoints

### DIFF
--- a/massive/rest/models/financials.py
+++ b/massive/rest/models/financials.py
@@ -923,6 +923,63 @@ class RiskFactorTaxonomy:
 
 
 @modelclass
+class Disclosure:
+    """
+    A single tagged disclosure within an SEC 8-K filing. A filing can produce
+    multiple disclosures, each classified into primary, secondary, and tertiary
+    categories with a supporting text excerpt.
+    """
+
+    accession_number: Optional[str] = None
+    cik: Optional[str] = None
+    filing_date: Optional[str] = None
+    filing_url: Optional[str] = None
+    primary_category: Optional[str] = None
+    secondary_category: Optional[str] = None
+    supporting_text: Optional[str] = None
+    tertiary_category: Optional[str] = None
+    tickers: Optional[List[str]] = None
+
+    @staticmethod
+    def from_dict(d):
+        return Disclosure(
+            accession_number=d.get("accession_number"),
+            cik=d.get("cik"),
+            filing_date=d.get("filing_date"),
+            filing_url=d.get("filing_url"),
+            primary_category=d.get("primary_category"),
+            secondary_category=d.get("secondary_category"),
+            supporting_text=d.get("supporting_text"),
+            tertiary_category=d.get("tertiary_category"),
+            tickers=d.get("tickers"),
+        )
+
+
+@modelclass
+class DisclosureTaxonomy:
+    """
+    A single 8-K disclosure classification, part of the complete list of
+    classifications used in the 8-K disclosures endpoint.
+    """
+
+    description: Optional[str] = None
+    primary_category: Optional[str] = None
+    secondary_category: Optional[str] = None
+    taxonomy: Optional[str] = None
+    tertiary_category: Optional[str] = None
+
+    @staticmethod
+    def from_dict(d):
+        return DisclosureTaxonomy(
+            description=d.get("description"),
+            primary_category=d.get("primary_category"),
+            secondary_category=d.get("secondary_category"),
+            taxonomy=d.get("taxonomy"),
+            tertiary_category=d.get("tertiary_category"),
+        )
+
+
+@modelclass
 @dataclass
 class Filing13F:
     """SEC Form 13F filings data showing institutional investment manager holdings."""

--- a/massive/rest/reference.py
+++ b/massive/rest/reference.py
@@ -28,6 +28,8 @@ from .models import (
     ShortVolume,
     RiskFactor,
     RiskFactorTaxonomy,
+    Disclosure,
+    DisclosureTaxonomy,
     FilingSection,
     Filing8K,
     Filing13F,
@@ -858,6 +860,88 @@ class ContractsClient(BaseClient):
             params=self._get_params(self.list_stocks_taxonomies_risk_factors, locals()),
             result_key="results",
             deserializer=RiskFactorTaxonomy.from_dict,
+            raw=raw,
+            options=options,
+        )
+
+    def list_stocks_filings_8k_disclosures(
+        self,
+        cik: Optional[str] = None,
+        cik_any_of: Optional[str] = None,
+        tickers: Optional[str] = None,
+        tickers_all_of: Optional[str] = None,
+        tickers_any_of: Optional[str] = None,
+        filing_date: Optional[Union[str, date]] = None,
+        filing_date_any_of: Optional[str] = None,
+        filing_date_gt: Optional[Union[str, date]] = None,
+        filing_date_gte: Optional[Union[str, date]] = None,
+        filing_date_lt: Optional[Union[str, date]] = None,
+        filing_date_lte: Optional[Union[str, date]] = None,
+        tertiary_category: Optional[str] = None,
+        limit: Optional[int] = 100,
+        sort: Optional[Union[str, Sort]] = "filing_date.desc",
+        params: Optional[Dict[str, Any]] = None,
+        raw: bool = False,
+        options: Optional[RequestOptionBuilder] = None,
+    ) -> Union[Iterator[Disclosure], HTTPResponse]:
+        """
+        SEC 8-K filing disclosure categorization. A single 8-K filing can produce
+        multiple rows when it covers multiple disclosure types, each classified into
+        primary, secondary, and tertiary categories with a supporting text excerpt.
+        The full classification list is available at /stocks/taxonomies/vX/disclosures.
+        """
+        url = "/stocks/filings/8-K/vX/disclosures"
+        return self._paginate(
+            path=url,
+            params=self._get_params(self.list_stocks_filings_8k_disclosures, locals()),
+            result_key="results",
+            deserializer=Disclosure.from_dict,
+            raw=raw,
+            options=options,
+        )
+
+    def list_stocks_taxonomies_disclosures(
+        self,
+        taxonomy: Optional[str] = None,
+        taxonomy_any_of: Optional[str] = None,
+        taxonomy_gt: Optional[str] = None,
+        taxonomy_gte: Optional[str] = None,
+        taxonomy_lt: Optional[str] = None,
+        taxonomy_lte: Optional[str] = None,
+        primary_category: Optional[str] = None,
+        primary_category_any_of: Optional[str] = None,
+        primary_category_gt: Optional[str] = None,
+        primary_category_gte: Optional[str] = None,
+        primary_category_lt: Optional[str] = None,
+        primary_category_lte: Optional[str] = None,
+        secondary_category: Optional[str] = None,
+        secondary_category_any_of: Optional[str] = None,
+        secondary_category_gt: Optional[str] = None,
+        secondary_category_gte: Optional[str] = None,
+        secondary_category_lt: Optional[str] = None,
+        secondary_category_lte: Optional[str] = None,
+        tertiary_category: Optional[str] = None,
+        tertiary_category_any_of: Optional[str] = None,
+        tertiary_category_gt: Optional[str] = None,
+        tertiary_category_gte: Optional[str] = None,
+        tertiary_category_lt: Optional[str] = None,
+        tertiary_category_lte: Optional[str] = None,
+        limit: Optional[int] = 200,
+        sort: Optional[Union[str, Sort]] = "taxonomy.desc",
+        params: Optional[Dict[str, Any]] = None,
+        raw: bool = False,
+        options: Optional[RequestOptionBuilder] = None,
+    ) -> Union[Iterator[DisclosureTaxonomy], HTTPResponse]:
+        """
+        The complete list of 8-K disclosure classifications used in the 8-K
+        disclosures endpoint.
+        """
+        url = "/stocks/taxonomies/vX/disclosures"
+        return self._paginate(
+            path=url,
+            params=self._get_params(self.list_stocks_taxonomies_disclosures, locals()),
+            result_key="results",
+            deserializer=DisclosureTaxonomy.from_dict,
             raw=raw,
             options=options,
         )


### PR DESCRIPTION
## Summary

Adds support for two new SEC filings vX endpoints, synced from the OpenAPI spec:

- `GET /stocks/filings/8-K/vX/disclosures` via `list_stocks_filings_8k_disclosures`, returning `Disclosure` results.
- `GET /stocks/taxonomies/vX/disclosures` via `list_stocks_taxonomies_disclosures`, returning `DisclosureTaxonomy` results.

Both methods live in `ContractsClient` alongside the other filings endpoints, and the `Disclosure` / `DisclosureTaxonomy` models mirror the existing `RiskFactor` / `RiskFactorTaxonomy` pattern.

## Files changed

- `massive/rest/reference.py` — two new `ContractsClient` methods + model imports
- `massive/rest/models/financials.py` — `Disclosure` and `DisclosureTaxonomy` models

## Testing

Both endpoints verified against the live API, including filter param translation (`filing_date.gte`, `primary_category`, etc.), pagination, and `raw=True`.